### PR TITLE
Closes #1: Only include disqus in jekyll production mode.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,4 +12,6 @@ layout: default
 
 {% include about_footer.html %}
 
-{% include disqus.html %}
+{% if jekyll.environment == "production" %}
+	{% include disqus.html %}
+{% endif %}


### PR DESCRIPTION
For an explanation, see:
  https://github.com/bk2dcradle/Chaplin/issues/1#issue-145389458
